### PR TITLE
Fixed missing python executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN \
 COPY ./src/api /app/api
 
 RUN \
+	ln -s /usr/bin/python3 /usr/bin/python && \
 	echo 'fixing requirements file for alpine' && \
 	sed -i '/Pillow/d' /app/api/requirements/base.txt && \
 	\


### PR DESCRIPTION
This fix [some build error](https://dev.funkwhale.audio/funkwhale/funkwhale/-/jobs/15778) I had recently:

```
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'error'
    Complete output from command /usr/bin/python3.6 /usr/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /tmp/tmp5dm7qq72:
    Traceback (most recent call last):
      File "/usr/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 64, in prepare_metadata_for_build_wheel
        hook = backend.prepare_metadata_for_build_wheel
    AttributeError: module 'poetry.masonry.api' has no attribute 'prepare_metadata_for_build_wheel'
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "/usr/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 207, in <module>
        main()
      File "/usr/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 197, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
      File "/usr/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 67, in prepare_metadata_for_build_wheel
        config_settings)
      File "/usr/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 95, in _get_wheel_metadata_from_wheel
        whl_basename = backend.build_wheel(metadata_directory, config_settings)
      File "/tmp/pip-build-env-i9u_zx6c/overlay/lib/python3.6/site-packages/poetry/masonry/api.py", line 40, in build_wheel
        poetry, SystemEnv(Path(sys.prefix)), NullIO(), Path(wheel_directory)
      File "/tmp/pip-build-env-i9u_zx6c/overlay/lib/python3.6/site-packages/poetry/masonry/builders/wheel.py", line 49, in make_in
        wb.build()
      File "/tmp/pip-build-env-i9u_zx6c/overlay/lib/python3.6/site-packages/poetry/masonry/builders/wheel.py", line 71, in build
        self._build(zip_file)
      File "/tmp/pip-build-env-i9u_zx6c/overlay/lib/python3.6/site-packages/poetry/masonry/builders/wheel.py", line 92, in _build
        "python", str(setup), "build", "-b", str(self._path / "build")
      File "/tmp/pip-build-env-i9u_zx6c/overlay/lib/python3.6/site-packages/poetry/utils/env.py", line 351, in run
        cmd, stderr=subprocess.STDOUT, **kwargs
      File "/usr/lib/python3.6/subprocess.py", line 336, in check_output
        **kwargs).stdout
      File "/usr/lib/python3.6/subprocess.py", line 403, in run
        with Popen(*popenargs, **kwargs) as process:
      File "/usr/lib/python3.6/subprocess.py", line 709, in __init__
        restore_signals, start_new_session)
      File "/usr/lib/python3.6/subprocess.py", line 1344, in _execute_child
        raise child_exception_type(errno_num, err_msg, err_filename)
    FileNotFoundError: [Errno 2] No such file or directory: 'python': 'python'
    
    ----------------------------------------
Command "/usr/bin/python3.6 /usr/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /tmp/tmp5dm7qq72" failed with error code 1 in /tmp/pip-install-1y9hdypk/pendulum
The command '/bin/sh -c echo 'fixing requirements file for alpine' && 	sed -i '/Pillow/d' /app/api/requirements/base.txt && 			echo 'installing pip requirements' && 	pip3 install --upgrade pip && 	pip3 install setuptools wheel && 	pip3 install -r /app/api/requirements.txt' returned a non-zero code: 1
ERROR: Job failed: exit status 1
```