### PR TITLE
Image repo change and superficial clean up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM alpine:3.8
 MAINTAINER thetarkus
 
+
 #
 # Installation
 #
+
 ARG arch=amd64
 RUN \
 	echo 'installing dependencies' && \
@@ -70,10 +72,13 @@ RUN \
 	pip3 install -r /app/api/requirements.txt
 
 COPY ./src/front /app/front
+
+
 #
 # Environment
 # https://dev.funkwhale.audio/funkwhale/funkwhale/blob/develop/deploy/env.prod.sample
-# (We put environment at the end to avoid busting build cache on each ENV change)
+# (Environment at the end to avoid busting build cache on each ENV change)
+#
 
 ENV FUNKWHALE_HOSTNAME=yourdomain.funkwhale \
 	FUNKWHALE_PROTOCOL=http \

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ ENV FUNKWHALE_HOSTNAME=yourdomain.funkwhale \
 	MUSIC_DIRECTORY_PATH=/music \
 	NGINX_MAX_BODY_SIZE=100M \
 	STATIC_ROOT=/app/api/staticfiles \
-        FUNKWHALE_SPA_HTML_ROOT=http://localhost/front/
+	FUNKWHALE_SPA_HTML_ROOT=http://localhost/front/
 
 #
 # Entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,11 +77,7 @@ COPY ./src/front /app/front
 #
 # Environment
 # https://dev.funkwhale.audio/funkwhale/funkwhale/blob/develop/deploy/env.prod.sample
-<<<<<<< HEAD
 # (Environment is at the end to avoid busting build cache on each ENV change)
-=======
-# (Environment at the end to avoid busting build cache on each ENV change)
->>>>>>> 05ca25163c27ac7652aa014f2f2ee6c72c714da1
 #
 
 ENV FUNKWHALE_HOSTNAME=yourdomain.funkwhale \

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ COPY ./src/front /app/front
 #
 # Environment
 # https://dev.funkwhale.audio/funkwhale/funkwhale/blob/develop/deploy/env.prod.sample
-# (Environment at the end to avoid busting build cache on each ENV change)
+# (Environment is at the end to avoid busting build cache on each ENV change)
 #
 
 ENV FUNKWHALE_HOSTNAME=yourdomain.funkwhale \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ docker create \
 	-v </path/to/data>:/data \
 	-v </path/to/path>:/music:ro \
 	-p 3030:80 \
-	thetarkus/funkwhale
+	funkwhale/all-in-one
 ```
 
 
@@ -44,20 +44,17 @@ docker exec -it funkwhale manage import_files $LIBRARY_ID "/music/**/**/*.mp3" -
 For more information see the [Funkwhale docs on importing music](https://docs.funkwhale.audio/importing-music.html).
 
 ### Build this image
+This image is built and pushed automatically on `funkwhale/all-in-one`, for all Funkwhale releases and for the development version as well (using the `develop` tag).
 
-This image is built and pushed automatically on `funkwhale/all-in-one`, for all Funkwhale
-releases and for the development version as well (using the `develop` tag).
-
-If you want to build it manually, you can run the following instructions:
-
+If you want to build it manually, you can run the following:
 ```bash
-image_name="mycustomimage"
-# replace develop by any tag or branch name
-version="develop"
+image_name='mycustomimage'  # choose a name for the image
+version='develop'  # replace 'develop' with any tag or branch name
+arch='amd64'  # set your cpu architecture
+
 # download Funkwhale front and api artifacts and nginx configuration
 ./scripts/download-artifact.sh src/ $version build_front
 ./scripts/download-artifact.sh src/ $version build_api
 ./scripts/download-nginx-template.sh src/ $version
-docker build -t $image_name:$version .
-
+docker build --build-arg $arch -t $image_name:$version .
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ docker create \
 	-v </path/to/data>:/data \
 	-v </path/to/path>:/music:ro \
 	-p 3030:80 \
-	funkwhale/all-in-one
+	thetarkus/funkwhale
 ```
 
 

--- a/scripts/download-artifact.sh
+++ b/scripts/download-artifact.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 dest_dir=$1
 artifact_version=$2
@@ -13,4 +14,4 @@ echo "Downloading $artifact_url to $dest_file…"
 wget "$artifact_url" -O $dest_file
 echo "Unzipping $dest_file to $dest_dir"
 unzip -o $dest_file -d $dest_dir
-echo "Done!"
+echo 'Done!'

--- a/scripts/download-nginx-template.sh
+++ b/scripts/download-nginx-template.sh
@@ -1,5 +1,5 @@
-
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 dest_dir=$1
 artifact_version=$2
@@ -11,12 +11,12 @@ mkdir -p $dest_dir
 dest_file="$dest_dir/funkwhale_nginx.template"
 echo "Downloading $artifact_url to $dest_file…"
 wget "$artifact_url" -O $dest_file
-echo "Fixing file content for use in our docker image…"
-sed -i "s/api:5000/127.0.0.1:8000/" $dest_file
-sed -i "s/listen 80;/listen 80 default_server;/" $dest_file
-sed -i "s/server_name \${FUNKWHALE_HOSTNAME};/server_name _;/" $dest_file
-sed -i "s/\$http_upgrade/\${_}http_upgrade/" $dest_file
-sed -i "s/\$connection_upgrade/\${_}connection_upgrade/" $dest_file
-sed -i "s|/frontend|/app/front/dist|" $dest_file
+echo 'Fixing file content for use in our docker image…'
+sed -i -e 's/api:5000/127.0.0.1:8000/' \
+	-e 's/listen 80;/listen 80 default_server;/' \
+	-e 's/server_name \${FUNKWHALE_HOSTNAME};/server_name _;/' \
+	-e 's/\$http_upgrade/\${_}http_upgrade/' \
+	-e 's/\$connection_upgrade/\${_}connection_upgrade/' \
+	-e 's|/frontend|/app/front/dist|' $dest_file
 
-echo "Done!"
+echo 'Done!'


### PR DESCRIPTION
Changed shebangs from `#!/bin/bash` in scripts to `#!/usr/bin/env bash` for maximum portability.

Added `arch` variable to the build example for issues like #14. (Which I'm not even sure works yet... So don't merge until this is resolved)

Superficial cleanings like spacing consistencies and clearer comments.