### PR TITLE
Fix glob handling in manage script

### DIFF
--- a/root/usr/local/bin/manage
+++ b/root/usr/local/bin/manage
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv sh
 cd /app/api
-exec s6-setuidgid funkwhale python3 manage.py $@
+exec s6-setuidgid funkwhale python3 manage.py "$@"


### PR DESCRIPTION
This is the cause of https://dev.funkwhale.audio/funkwhale/funkwhale/issues/690, where running the `manage` script with arguments containing globs (like `music/*.mp3`) would unpack glob match instead of passing the glob to the funkwhale script, causing breakage and unexpected behaviours :)

Adding the quotes seems to be backward compatible AND solve the issue.