### PR TITLE
Load local front-end HTML to avoid networking issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ ENV FUNKWHALE_HOSTNAME=yourdomain.funkwhale \
 	MUSIC_DIRECTORY_PATH=/music \
 	NGINX_MAX_BODY_SIZE=100M \
 	STATIC_ROOT=/app/api/staticfiles \
-	FUNKWHALE_SPA_HTML_ROOT=http://localhost/front/
+	FUNKWHALE_SPA_HTML_ROOT=/app/front/dist/index.html
 
 #
 # Entrypoint


### PR DESCRIPTION
Just a small improvement to avoid triggering HTTP requests, because we know the front-end HTML is available locally