### PR TITLE
Fix #19: added support for nested proxy via the NESTED_PROXY=1 variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ docker exec -it funkwhale manage import_files $LIBRARY_ID "/music/**/**/*.mp3" -
 ```
 For more information see the [Funkwhale docs on importing music](https://docs.funkwhale.audio/importing-music.html).
 
+### Running behind a proxy
+
+In more involved deployments, you may have a reverse proxy in front of the container.
+
+If it is the case, add the `-e NESTED_PROXY=1` flag to the docker run command, or ensure
+`NESTED_PROXY=1` is available in the container environment.
+
 ### Build this image
 This image is built and pushed automatically on `funkwhale/all-in-one`, for all Funkwhale releases and for the development version as well (using the `develop` tag).
 

--- a/root/etc/cont-init.d/50-webserver
+++ b/root/etc/cont-init.d/50-webserver
@@ -1,2 +1,6 @@
 #!/usr/bin/with-contenv sh
+if [ "$NESTED_PROXY" = "1" ]; then
+    echo "Setting up nested proxy conf…"
+    cp /etc/nginx/funkwhale_proxy_nested.conf /etc/nginx/funkwhale_proxy.conf
+fi
 _=$ envsubst < /etc/nginx/funkwhale_nginx.template > /etc/nginx/conf.d/funkwhale.conf

--- a/root/etc/nginx/funkwhale_proxy_nested.conf
+++ b/root/etc/nginx/funkwhale_proxy_nested.conf
@@ -1,0 +1,14 @@
+# when the container is run behind another proxy, we need different X-Forwarded
+# instructions, see https://github.com/thetarkus/docker-funkwhale/issues/19 for
+# more info
+proxy_set_header Host $http_x_forwarded_host;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+proxy_set_header X-Forwarded-Host $http_x_forwarded_host;
+proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
+proxy_redirect off;
+
+# websocket support
+proxy_http_version 1.1;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $connection_upgrade;


### PR DESCRIPTION
This closes #19 by using an alternative proxy file if `NESTED_PROXY=1` is available in the container environment 