### PR TITLE
Fix wrong cover url issue

### DIFF
--- a/root/etc/nginx/funkwhale_proxy_nested.conf
+++ b/root/etc/nginx/funkwhale_proxy_nested.conf
@@ -2,6 +2,7 @@
 # instructions, see https://github.com/thetarkus/docker-funkwhale/issues/19 for
 # more info
 proxy_set_header Host $http_x_forwarded_host;
+proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
 proxy_set_header X-Forwarded-Host $http_x_forwarded_host;


### PR DESCRIPTION
A faulty nested proxy configuration caused cover URL to be relative to 127.0.0.1 instead of the actual funkwhale instance base URL. The issue was fixed adding a configuration line from the non-nested config file, which was determining the cover arts to be correctly rendered in that configuration.