### PR TITLE
Improved cachability of image layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,8 @@ RUN \
 	echo 'removing temp files' && \
 	rm /tmp/*.tar.gz
 
-COPY ./src/api /app/api
+COPY ./src/api/requirements.txt /app/api/requirements.txt
+COPY ./src/api/requirements/ /app/api/requirements/
 
 RUN \
 	ln -s /usr/bin/python3 /usr/bin/python && \
@@ -73,6 +74,7 @@ RUN \
 	pip3 install -r /app/api/requirements.txt && \
 	pip3 install gunicorn uvicorn
 
+COPY ./src/api/ /app/api/
 COPY ./src/front /app/front
 
 


### PR DESCRIPTION
By copying only requirements, installing, and then copyring the whole source code, we improve the cachability of docker image layers, which in turn reduce the load on our CI servers when building the `develop` image after each merge ;)

Tested locally, merging right away.