### PR TITLE
Support setting CELERYD_CONCURRENCY to control number of spawned…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,8 @@ ENV FUNKWHALE_HOSTNAME=yourdomain.funkwhale \
 	NGINX_MAX_BODY_SIZE=100M \
 	STATIC_ROOT=/app/api/staticfiles \
 	FUNKWHALE_SPA_HTML_ROOT=/app/front/dist/index.html \
-	FUNKWHALE_WEB_WORKERS=1
+	FUNKWHALE_WEB_WORKERS=1 \
+	CELERYD_CONCURRENCY=0
 #
 # Entrypoint
 #

--- a/root/etc/services.d/celery-worker/run
+++ b/root/etc/services.d/celery-worker/run
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv sh
 cd /app/api
-exec s6-setuidgid funkwhale celery -f /var/log/funkwhale/celery-worker.log -A funkwhale_api.taskapp worker
+exec s6-setuidgid funkwhale celery -f /var/log/funkwhale/celery-worker.log -A funkwhale_api.taskapp worker --concurrency=$CELERYD_CONCURRENCY


### PR DESCRIPTION
Fully backward compatible change, corresponding issue on Funkwhale repo: https://dev.funkwhale.audio/funkwhale/funkwhale/issues/997

`0` as default means a number of processes equal to the number of core will be spawned :)