### PR TITLE
Celery command syntax has changed

### DIFF
--- a/root/etc/services.d/celery-beat/run
+++ b/root/etc/services.d/celery-beat/run
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv sh
 cd /app/api
-exec s6-setuidgid funkwhale celery -f /var/log/funkwhale/celery-beat.log -A funkwhale_api.taskapp beat --pidfile=
+exec s6-setuidgid funkwhale celery -A funkwhale_api.taskapp beat --pidfile= -f /var/log/funkwhale/celery-beat.log

--- a/root/etc/services.d/celery-worker/run
+++ b/root/etc/services.d/celery-worker/run
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv sh
 cd /app/api
-exec s6-setuidgid funkwhale celery -f /var/log/funkwhale/celery-worker.log -A funkwhale_api.taskapp worker --concurrency=$CELERYD_CONCURRENCY
+exec s6-setuidgid funkwhale celery -A funkwhale_api.taskapp worker --concurrency=$CELERYD_CONCURRENCY -f /var/log/funkwhale/celery-worker.log


### PR DESCRIPTION
Hi!

Version 1.2.0 of funkwhale bundles a new version of celery, which moves the `-f <logfile>` argument to the sub-command rather than making it a global argument. My funkwhale wouldn't work since the workers refused to startup because they didn't recognize `-f /var/log/celery-beat.log` as a valid argument in its current position.

I don't know if this fix is good enough or if you want to maintain backwards-compatibility with older versions of funkwhale? In that case I can add a check based on `celery --version`. I'll admit I don't know much about celery and I haven't taken the t ime to go upstream to check exactly when this broke.